### PR TITLE
fix vscodium install instructions for ubuntu

### DIFF
--- a/content/Neovim/22-vscodium-neovim.md
+++ b/content/Neovim/22-vscodium-neovim.md
@@ -31,16 +31,16 @@ Microsoft’s vscode source code is open source (MIT-licensed), but the product 
 Either:
 
 ```
+snap install codium
+```
+
+or: (note use of sudo in each line)
+
+```
 wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/vscodium-archive-keyring.gpg
 echo 'deb [signed-by=/etc/apt/trusted.gpg.d/vscodium-archive-keyring.gpg] https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs/ vscodium main' | sudo tee /etc/apt/sources.list.d/vscodium.list
 sudo apt update
 sudo apt install codium
-```
-
-or:
-
-```
-snap install codium
 ```
 
 ### Configuring Plugins

--- a/content/Neovim/22-vscodium-neovim.md
+++ b/content/Neovim/22-vscodium-neovim.md
@@ -69,7 +69,7 @@ From here the path is `Contents/Resources/app/product.json`
 Here is the path to `product.json` on Linux:
 
 ```
-/usr/share/vscodium-bin/resources/app/product.json
+/usr/share/codium/resources/app/product.json
 ```
 
 ## The Neovim Extension

--- a/content/Neovim/22-vscodium-neovim.md
+++ b/content/Neovim/22-vscodium-neovim.md
@@ -28,9 +28,20 @@ Microsoft’s vscode source code is open source (MIT-licensed), but the product 
 
 - Ubuntu
 
-  ```
-  sudo apt install vscodium
-  ```
+Either:
+
+```
+wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/vscodium-archive-keyring.gpg
+echo 'deb [signed-by=/etc/apt/trusted.gpg.d/vscodium-archive-keyring.gpg] https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs/ vscodium main' | sudo tee /etc/apt/sources.list.d/vscodium.list
+sudo apt update
+sudo apt install codium
+```
+
+or:
+
+```
+snap install codium
+```
 
 ### Configuring Plugins
 


### PR DESCRIPTION
As far as I can tell, the standard apt repositories do not have vscodium. This fix adds the lines to add the repo/keys for codium for those who want to use apt, and it also specifies an option to install via snap instead.

 This is my first pull request, apologies if I'm missing something.  