### PR TITLE
Updated brew install commands for cask modules 

### DIFF
--- a/content/Linux/06-alacritty.md
+++ b/content/Linux/06-alacritty.md
@@ -19,7 +19,7 @@ From the repo:
 - Mac
 
   ```
-  brew cask install alacritty
+  brew install --cask alacritty
   ```
 
 - Ubuntu

--- a/content/Neovim/22-vscodium-neovim.md
+++ b/content/Neovim/22-vscodium-neovim.md
@@ -17,7 +17,7 @@ Microsoft’s vscode source code is open source (MIT-licensed), but the product 
 - On Mac
 
   ```
-  brew cask install vscodium
+  brew install --cask vscodium
   ```
 
 - Arch Linux


### PR DESCRIPTION
New versions of brew dropped support for `cask` and recommends `--cask` flag instead.

![Screenshot 2021-02-08 at 12 48 58 PM](https://user-images.githubusercontent.com/27001046/107187450-07ec2380-6a0c-11eb-847e-51c1790505c7.png)

![Screenshot 2021-02-08 at 12 53 20 PM](https://user-images.githubusercontent.com/27001046/107187839-a4aec100-6a0c-11eb-894f-a9a22f509969.png)
