### PR TITLE
SEO: Add Meta Tags to blog posts

### DIFF
--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-function SEO({ description, lang, meta, title }) {
+function SEO({ description, lang, meta, title, keywords }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -19,6 +19,7 @@ function SEO({ description, lang, meta, title }) {
   )
 
   const metaDescription = description || site.siteMetadata.description
+  const author = site.siteMetadata.author || "Chris"
 
   return (
     <Helmet
@@ -63,11 +64,19 @@ function SEO({ description, lang, meta, title }) {
       ].concat(meta)}
     >
       <html lang="en" />
-      <title>{site.siteMetadata.title}</title>
+      <title>{title}</title>
       <meta
         name="google-site-verification"
         content="8XINwkJ1ddUZTNLbqRwI0wqBIg6cwpTklXzLjQ6H4Bk"
       />
+
+      {title && <meta property="og:title" content={title} />}
+      {metaDescription && (
+          <meta property="og:description" content={metaDescription} />
+        ) && <meta name="description" content={metaDescription} />}
+      {keywords && <meta property="keywords" content={keywords} />}
+      {author && <meta property="author" content={author} />}
+
     </Helmet>
   )
 }

--- a/src/templates/blog-post.jsx
+++ b/src/templates/blog-post.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Layout from "../components/layout"
+import SEO from "../components/seo"
 import Img from "gatsby-image"
 import { graphql } from "gatsby"
 import PostPager from "../components/post-pager"
@@ -43,6 +44,7 @@ function BlogPost(props) {
 
   return (
     <Layout>
+      <SEO title={title} keywords={tags} />
       <div>
         {image && (
           <Img


### PR DESCRIPTION
### update `seo.jsx`
- render <meta> tags 
- use blog post title as title for current page
> The title will look something like:
   > <title>The Title of Blog Post | Chris@Machine</title>
  Example: https://ayush-blog.netlify.app/Git/05-Playing-Detective/
### update `blost-post.jsx`
- render the <SEO /> component 
- pass in title and keywords props

Originally fixed for my own blog.
PR: https://github.com/ayushxx7/ayush-mandowara-blog/pull/11
Commit: https://github.com/ayushxx7/ayush-mandowara-blog/pull/11/commits/f80fdd57244327eec29a514f7c30a334b8fea1e2

Note: `<meta>` tag for description uses site description (`site.siteMetadata.description`). I haven't figured out how to add the current blog post description yet.

Closes https://github.com/ChristianChiarulli/blog/issues/14