### PR TITLE
SEO: Add description Meta Tag

### DIFF
--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-function SEO({ description, lang, meta, title }) {
+function SEO({ description, lang, meta, title, keywords }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -19,6 +19,7 @@ function SEO({ description, lang, meta, title }) {
   )
 
   const metaDescription = description || site.siteMetadata.description
+  const author = site.siteMetadata.author || "Chris"
 
   return (
     <Helmet
@@ -63,11 +64,19 @@ function SEO({ description, lang, meta, title }) {
       ].concat(meta)}
     >
       <html lang="en" />
-      <title>{site.siteMetadata.title}</title>
+      <title>{title}</title>
       <meta
         name="google-site-verification"
         content="8XINwkJ1ddUZTNLbqRwI0wqBIg6cwpTklXzLjQ6H4Bk"
       />
+
+      {title && <meta property="og:title" content={title} />}
+      {metaDescription && (
+          <meta property="og:description" content={metaDescription} />
+        ) && <meta name="description" content={metaDescription} />}
+      {keywords && <meta property="keywords" content={keywords} />}
+      {author && <meta property="author" content={author} />}
+
     </Helmet>
   )
 }

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -70,12 +70,16 @@ function SEO({ description, lang, meta, title, keywords }) {
         content="8XINwkJ1ddUZTNLbqRwI0wqBIg6cwpTklXzLjQ6H4Bk"
       />
 
-      {title && <meta property="og:title" content={title} />}
+      {title && <meta name="title" property="og:title" content={title} />}
       {metaDescription && (
-          <meta property="og:description" content={metaDescription} />
-        ) && <meta name="description" content={metaDescription} />}
-      {keywords && <meta property="keywords" content={keywords} />}
-      {author && <meta property="author" content={author} />}
+        <meta
+          name="description"
+          property="og:description"
+          content={metaDescription}
+        />
+      )}
+      {keywords && <meta name="keywords" content={keywords} />}
+      {author && <meta name="author" content={author} />}
 
     </Helmet>
   )

--- a/src/templates/blog-post.jsx
+++ b/src/templates/blog-post.jsx
@@ -11,7 +11,7 @@ import loadable from "@loadable/component"
 import "@suziwen/gitalk/dist/gitalk.css"
 
 function BlogPost(props) {
-  const { title, image, tags } = props.data.markdownRemark.frontmatter
+  const {title, image, tags, description} = props.data.markdownRemark.frontmatter
   const { prev, next } = props.pageContext
   const { id } = props.data.markdownRemark
 
@@ -44,7 +44,7 @@ function BlogPost(props) {
 
   return (
     <Layout>
-      <SEO title={title} keywords={tags} />
+      <SEO title={title} keywords={tags} description={description} />
       <div>
         {image && (
           <Img
@@ -87,6 +87,7 @@ export const query = graphql`
       frontmatter {
         title
         tags
+        description
         image {
           childImageSharp {
             resize(width: 1000, height: 420) {

--- a/src/templates/blog-post.jsx
+++ b/src/templates/blog-post.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Layout from "../components/layout"
+import SEO from "../components/seo"
 import Img from "gatsby-image"
 import { graphql } from "gatsby"
 import PostPager from "../components/post-pager"
@@ -43,6 +44,7 @@ function BlogPost(props) {
 
   return (
     <Layout>
+      <SEO title={title} keywords={tags} />
       <div>
         {image && (
           <Img


### PR DESCRIPTION
Using GraphQL to fetch description from the frontmatter of the blog and passing it down to the SEO component. This solves the note from #15 and closes #14.
See https://github.com/ChristianChiarulli/blog/commit/b2de27c085e8399b745ab24aa43f3bc4c14e076f for more details.

Note: As per line 21 in `seo.jsx`, if the description is not present in the frontmatter, the site description will be used.
```js
const metaDescription = description || site.siteMetadata.description
```

Corresponding PR in my blog: https://github.com/ayushxx7/ayush-mandowara-blog/pull/34