### PR TITLE
Replacing pyright with pylsp

### DIFF
--- a/content/Neovim/27-native-lsp.md
+++ b/content/Neovim/27-native-lsp.md
@@ -148,10 +148,10 @@ Here are some examples:
 
 **Python:**
 
-- Install language server: `npm i -g pyright`
+- Install language server: `pip install python-lsp-server`
 - Configure language server:
     ```lua heading="python-lsp.lua" 
-    require'lspconfig'.pyright.setup{}
+    require'lspconfig'.pylsp.setup{}
     ```
 
 **Bash:**


### PR DESCRIPTION
For some reason pyright is not working as expected for auto-formating
pyright is less featureful than pylsp